### PR TITLE
Fix "npm run createpkg"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ A [Visual Studio Code](https://code.visualstudio.com/) extension that provides d
 - Locate the .vsix file you download and click "Open".
 - Click "Restart" to confirm.
 
-[Installing the extension](docs/images/install-from-vsix.png)
-<!-- <img alt="Installing the extension" src="./docs/images/install-from-vsix.png?raw=true" width="600"><br> -->
+![Installing the extension](./docs/images/install-from-vsix.png)
 
 **Step 2.** Create a new DataPlugin. Launch VS Code Command Palette (Ctrl+Shift+P), paste the following command, and press enter.
 
@@ -22,7 +21,7 @@ A [Visual Studio Code](https://code.visualstudio.com/) extension that provides d
 NI DataPlugins: Create new Python-DataPlugin
 ```
 
-<img alt="Creating a new DataPlugin" src="./docs/images/create-new-dataplugin.gif?raw=true" width="600"><br>
+![Creating a new DataPlugin](./docs/images/create-new-dataplugin.gif)
 
 **Step 3.** Export the DataPlugin. Right click on the \*.py file you want to export -> Choose "NI DataPlugins: Export DataPlugin". Create a file `.file-extensions` in the root directory of your project and list all file extensions that your DataPlugin should support. If no list is defined, you will be prompted to provide a list of file extensions on first export of your DataPlugin.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ A [Visual Studio Code](https://code.visualstudio.com/) extension that provides d
 - Locate the .vsix file you download and click "Open".
 - Click "Restart" to confirm.
 
-<img alt="Installing the extension" src="./docs/images/install-from-vsix.png?raw=true" width="600"><br>
+[Installing the extension](docs/images/install-from-vsix.png)
+<!-- <img alt="Installing the extension" src="./docs/images/install-from-vsix.png?raw=true" width="600"><br> -->
 
 **Step 2.** Create a new DataPlugin. Launch VS Code Command Palette (Ctrl+Shift+P), paste the following command, and press enter.
 


### PR DESCRIPTION
# Justification
- Creating a new vsix failed locally because README.md images source were not served by https
- This is solved by using the Github syntax for image embedding