### PR TITLE
Export embedded dataplugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
         "@types/uuid": "^8.3.0",
+        "crc": "^3.8.0",
         "fs-extra": "^9.0.1",
         "guid-typescript": "^1.0.9",
         "open": "^7.3.0"
       },
       "devDependencies": {
         "@ni/eslint-config": "^1.0.0",
+        "@types/crc": "^3.4.0",
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.2.2",
         "@types/node": "^14.14.13",
@@ -336,6 +338,15 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@types/crc": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/crc/-/crc-3.4.0.tgz",
+      "integrity": "sha1-I2a+tDmc1zSzPkLHrICVduYX1Io=",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/fs-extra": {
@@ -942,6 +953,25 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1129,6 +1159,29 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/buffer-alloc": {
       "version": "1.2.0",
@@ -1765,6 +1818,14 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
     },
     "node_modules/create-error-class": {
       "version": "3.0.2",
@@ -3675,6 +3736,25 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "5.1.8",
@@ -8471,6 +8551,15 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/crc": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/crc/-/crc-3.4.0.tgz",
+      "integrity": "sha1-I2a+tDmc1zSzPkLHrICVduYX1Io=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/fs-extra": {
       "version": "9.0.11",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.11.tgz",
@@ -8908,6 +8997,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -9064,6 +9158,15 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "buffer-alloc": {
       "version": "1.2.0",
@@ -9582,6 +9685,14 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "requires": {
+        "buffer": "^5.1.0"
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -11109,6 +11220,11 @@
         "agent-base": "6",
         "debug": "4"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.1.8",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,16 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "nipy.exportPlugin",
+          "when": "false"
+        },
+        {
+          "command": "nipy.registerPlugin",
+          "when": "false"
+        }
+      ],
       "explorer/context": [
         {
           "when": "resourceLangId == python",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   },
   "devDependencies": {
     "@ni/eslint-config": "^1.0.0",
+    "@types/crc": "^3.4.0",
     "@types/glob": "^7.1.3",
     "@types/mocha": "^8.2.2",
     "@types/node": "^14.14.13",
@@ -117,6 +118,7 @@
   "dependencies": {
     "@types/fs-extra": "^9.0.11",
     "@types/uuid": "^8.3.0",
+    "crc": "^3.8.0",
     "fs-extra": "^9.0.1",
     "guid-typescript": "^1.0.9",
     "open": "^7.3.0"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -118,7 +118,7 @@ export async function exportPlugin(uri: vscode.Uri): Promise<void> {
         exportPath = path.join(exportPath, `${pluginName}.uri`);
     }
 
-    await vscu.exportDataPlugin(scriptPath, extensions.toString(), `${exportPath}`);
+    await vscu.exportDataPlugin(scriptPath, extensions.toString(), `${exportPath}`, true);
 
     // Store selected extensions so we don't have to ask again
     fileutils.storeFileExtensionConfig(path.dirname(scriptPath), extensions);
@@ -133,7 +133,7 @@ export async function registerPlugin(uri: vscode.Uri): Promise<void> {
         return;
     }
 
-    await vscu.exportDataPlugin(scriptPath, extensions.toString(), `${exportPath}`, false);
+    await vscu.exportDataPlugin(scriptPath, extensions.toString(), `${exportPath}`);
     const process = await open(exportPath);
     process.on('exit', rc => {
         const foundUsiReg = rc === 0;

--- a/src/crc.ts
+++ b/src/crc.ts
@@ -2,8 +2,8 @@ import { crc32 } from 'crc';
 
 class CRC {
     public static crc32(data: string): number {
+        // The NI DataPlugins checksum is generated from a utf16le string
         const buffer = Buffer.from(data, 'utf16le');
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
         return crc32(buffer);
     }
 }

--- a/src/crc.ts
+++ b/src/crc.ts
@@ -1,0 +1,11 @@
+import { crc32 } from 'crc';
+
+class CRC {
+    public static crc32(data: string): number {
+        const buffer = Buffer.from(data, 'utf16le');
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
+        return crc32(buffer);
+    }
+}
+
+export default CRC;

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as readline from 'readline';
+import CRC from './crc';
 import { UriTemplate, PythonScript } from './uri-template';
 
 export async function readFirstLineOfFile(filePath: string): Promise<string> {
@@ -42,16 +43,32 @@ export function storeFileExtensionConfig(workspaceDir: string, fileExtensions: s
     }
 }
 
+/**
+ * @param scriptPath full file path to script that is exported
+ * @param fileExtensions supported file extensions of the DataPlugin
+ * @param exportPath full path to
+ * @param embedScript embed the script inside uri file
+ */
 export async function writeUriFile(
     scriptPath: string,
     fileExtensions: string,
-    exportPath: string
+    exportPath: string,
+    embedScript = false
 ): Promise<void> {
-    const dirName = path.basename(path.dirname(scriptPath));
-    const pyScript: PythonScript = {
-        content: 'asdasd',
-        checksum: 123
-    };
-    const uriTemplate = new UriTemplate(`${dirName}`, pyScript, fileExtensions);
+    const pluginName = path.basename(path.dirname(scriptPath));
+
+    let uriTemplate: UriTemplate;
+    if (embedScript) {
+        const fileContent = fs.readFileSync(scriptPath, { encoding: 'utf8' });
+        const pyScript: PythonScript = {
+            content: fileContent,
+            checksum: CRC.crc32(fileContent),
+            fullPath: scriptPath
+        };
+        uriTemplate = new UriTemplate(pluginName, pyScript, fileExtensions);
+    } else {
+        uriTemplate = new UriTemplate(pluginName, scriptPath, fileExtensions);
+    }
+
     await fs.writeFile(exportPath, uriTemplate.templateString, { flag: 'w' });
 }

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as readline from 'readline';
-import UriTemplate from './uri-template';
+import { UriTemplate, PythonScript } from './uri-template';
 
 export async function readFirstLineOfFile(filePath: string): Promise<string> {
     const rl = readline.createInterface({
@@ -48,6 +48,10 @@ export async function writeUriFile(
     exportPath: string
 ): Promise<void> {
     const dirName = path.basename(path.dirname(scriptPath));
-    const uriTemplate = new UriTemplate(`${dirName}`, scriptPath, fileExtensions);
+    const pyScript: PythonScript = {
+        content: 'asdasd',
+        checksum: 123
+    };
+    const uriTemplate = new UriTemplate(`${dirName}`, pyScript, fileExtensions);
     await fs.writeFile(exportPath, uriTemplate.templateString, { flag: 'w' });
 }

--- a/src/test/suite/crc.test.ts
+++ b/src/test/suite/crc.test.ts
@@ -1,0 +1,16 @@
+import * as assert from 'assert';
+import CRC from '../../crc';
+
+suite('CRC Test Suite', () => {
+    test('should create the correct crc of a simple string', () => {
+        const expectedResult = 1698750118;
+        const crc = CRC.crc32('class Plugin:');
+        assert.ok(expectedResult === crc);
+    });
+
+    test('should create the correct crc of a more complex string', () => {
+        const expectedResult = 337652373;
+        const crc = CRC.crc32('class Plugin: コピ ✔❌😊');
+        assert.ok(expectedResult === crc);
+    });
+});

--- a/src/test/suite/file-utils.test.ts
+++ b/src/test/suite/file-utils.test.ts
@@ -31,4 +31,36 @@ suite('File-Utils Test Suite', () => {
         const firstLine: string = await fileutils.readFirstLineOfFile(filePath);
         assert.ok(firstLine === '{');
     }).timeout(10000);
+
+    test('should correctly reference script and not embed it', async () => {
+        const testScript: string = path.join(__dirname, 'test.py');
+        const outputUri = path.join(__dirname, 'output.uri');
+
+        if (fs.existsSync(testScript)) {
+            fs.unlinkSync(testScript);
+        }
+
+        await fs.writeFile(testScript, 'class Plugin:');
+        await fileutils.writeUriFile(testScript, '*.csv', outputUri);
+
+        const fileContent = fs.readFileSync(outputUri, { encoding: 'utf8' });
+        assert.ok(fileContent.includes('CDATA[class Plugin:]') === false);
+        assert.ok(fileContent.includes('1698750118') === false);
+    }).timeout(10000);
+
+    test('should correctly embed script in uri file', async () => {
+        const testScript: string = path.join(__dirname, 'test.py');
+        const outputUri = path.join(__dirname, 'output.uri');
+
+        if (fs.existsSync(testScript)) {
+            fs.unlinkSync(testScript);
+        }
+
+        await fs.writeFile(testScript, 'class Plugin:');
+        await fileutils.writeUriFile(testScript, '*.csv', outputUri, true);
+
+        const fileContent = fs.readFileSync(outputUri, { encoding: 'utf8' });
+        assert.ok(fileContent.includes('CDATA[class Plugin:]'));
+        assert.ok(fileContent.includes('1698750118'));
+    }).timeout(10000);
 });

--- a/src/test/suite/uri-template.test.ts
+++ b/src/test/suite/uri-template.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { UriTemplate, PythonScript } from '../../uri-template';
+
+suite('URI-Template Test Suite', () => {
+    void vscode.window.showInformationMessage('Start URI template tests.');
+
+    test('should correctly construct a uri template that references a script', async () => {
+        const dataPluginName = 'MyDataPlugin';
+        const scriptPath = 'C:/temp/script.py';
+        const fileExtensions = '*.csv';
+
+        const comparison =
+            `<usireginfo><storetype name="${dataPluginName}">` +
+            '<type>python</type>' +
+            `<alias>${dataPluginName}</alias>` +
+            `<description>${dataPluginName}</description>` +
+            '<filepath>uspTdmMarshaller.dll</filepath>' +
+            '<exportsupported>NO</exportsupported>' +
+            '<caching>YES</caching>' +
+            '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>' +
+            '<querysupported>0</querysupported>' +
+            '<fastloadsupported>0</fastloadsupported>' +
+            `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
+            `<script>${scriptPath}</script>]]></easypluginparam>` +
+            '<platform>x64</platform></storetype></usireginfo>';
+
+        const uriTemplate = new UriTemplate('MyDataPlugin', 'C:/temp/script.py', '*.csv');
+        const templateString = uriTemplate.templateString;
+        assert.strictEqual(comparison, templateString);
+    }).timeout(10000);
+
+    test('should correctly construct a uri template that embeds a script', async () => {
+        const dataPluginName = 'MyDataPlugin';
+        const scriptPath = 'C:/temp/script.py';
+        const fileExtensions = '*.csv';
+        const pythonScript: PythonScript = {
+            content: 'class Plugin:',
+            checksum: 1698750118,
+            fullPath: scriptPath
+        };
+
+        const comparison =
+            `<usireginfo><storetype name="${dataPluginName}">` +
+            '<type>python</type>' +
+            `<alias>${dataPluginName}</alias>` +
+            `<description>${dataPluginName}</description>` +
+            '<filepath>uspTdmMarshaller.dll</filepath>' +
+            '<exportsupported>NO</exportsupported>' +
+            '<caching>YES</caching>' +
+            '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>' +
+            '<querysupported>0</querysupported>' +
+            '<fastloadsupported>0</fastloadsupported>' +
+            `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
+            `<script>@USIPLUGINDIREX@DataPlugins\\${dataPluginName}\\script.py</script>]]></easypluginparam>` +
+            '<platform>x64</platform></storetype>' +
+            `<files><file name="${dataPluginName}"><![CDATA[${pythonScript.content}]]>` +
+            `<checksum>${pythonScript.checksum}</checksum></file></files></usireginfo>`;
+
+        const uriTemplate = new UriTemplate('MyDataPlugin', pythonScript, '*.csv');
+        const templateString = uriTemplate.templateString;
+        assert.strictEqual(comparison, templateString);
+    }).timeout(10000);
+});

--- a/src/uri-template.ts
+++ b/src/uri-template.ts
@@ -1,48 +1,50 @@
+import * as path from 'path';
+
 export interface PythonScript {
     content: string;
     checksum: number;
+    fullPath: string;
 }
 
 export class UriTemplate {
     private readonly _templateString: string = '';
     /**
-     * @param fileName file name of script
-     * @param pythonScript full file path to script or file content and its crc32 checksum
+     * @param dataPluginName name of DataPlugin and uri
+     * @param pythonScript full file path to script or object of file content, crc32 and name
      * @param fileExtensions supported file extensions of the DataPlugin
      */
     public constructor(
-        fileName: string,
+        dataPluginName: string,
         pythonScript: string | PythonScript,
         fileExtensions: string
     ) {
+        this._templateString =
+            `<usireginfo><storetype name="${dataPluginName}">` +
+            '<type>python</type>' +
+            `<alias>${dataPluginName}</alias>` +
+            `<description>${dataPluginName}</description>` +
+            '<filepath>uspTdmMarshaller.dll</filepath>' +
+            '<exportsupported>NO</exportsupported>' +
+            '<caching>YES</caching>';
+
         if (typeof pythonScript === 'string') {
-            this._templateString =
-                `<usireginfo><storetype name="${fileName}">` +
-                '<type>python</type>' +
-                `<alias>${fileName}</alias>` +
-                `<description>${fileName}</description>` +
-                '<filepath>uspTdmMarshaller.dll</filepath>' +
-                '<exportsupported>NO</exportsupported>' +
-                '<caching>YES</caching>' +
+            this._templateString +=
                 `<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath><script>${pythonScript}</script>]]></easypluginparam>` +
                 '<querysupported>0</querysupported>' +
                 '<fastloadsupported>0</fastloadsupported>' +
-                `<filefilters extension="${fileExtensions}"><description>${fileName} Files (${fileExtensions})</description></filefilters>` +
+                `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
                 '<platform>x64</platform></storetype></usireginfo>';
         } else {
-            this._templateString =
-                `<usireginfo><storetype name="${fileName}">` +
-                '<type>python</type>' +
-                `<alias>${fileName}</alias>` +
-                `<description>${fileName}</description>` +
-                '<filepath>uspTdmMarshaller.dll</filepath>' +
-                '<exportsupported>NO</exportsupported>' +
-                '<caching>YES</caching>' +
-                `<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath><script>${pythonScript.content}</script>]]></easypluginparam>` +
+            const pyScriptName: string = path.basename(pythonScript.fullPath);
+            this._templateString +=
+                `<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath><script>@USIPLUGINDIREX@DataPlugins\\${dataPluginName}\\${pyScriptName}</script>]]></easypluginparam>` +
                 '<querysupported>0</querysupported>' +
                 '<fastloadsupported>0</fastloadsupported>' +
-                `<filefilters extension="${fileExtensions}"><description>${fileName} Files (${fileExtensions})</description></filefilters>` +
-                '<platform>x64</platform></storetype></usireginfo>';
+                `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
+                '<platform>x64</platform></storetype>' +
+                `<files><file name="${dataPluginName}"><![CDATA[${pythonScript.content}]]>` +
+                `<checksum>${pythonScript.checksum}</checksum></file></files>` +
+                '</usireginfo>';
         }
     }
 

--- a/src/uri-template.ts
+++ b/src/uri-template.ts
@@ -25,27 +25,26 @@ export class UriTemplate {
             `<description>${dataPluginName}</description>` +
             '<filepath>uspTdmMarshaller.dll</filepath>' +
             '<exportsupported>NO</exportsupported>' +
-            '<caching>YES</caching>';
+            '<caching>YES</caching>' +
+            '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>' +
+            '<querysupported>0</querysupported>' +
+            '<fastloadsupported>0</fastloadsupported>' +
+            `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>`;
 
         if (typeof pythonScript === 'string') {
             this._templateString +=
-                `<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath><script>${pythonScript}</script>]]></easypluginparam>` +
-                '<querysupported>0</querysupported>' +
-                '<fastloadsupported>0</fastloadsupported>' +
-                `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
-                '<platform>x64</platform></storetype></usireginfo>';
+                `<script>${pythonScript}</script>]]></easypluginparam>` +
+                '<platform>x64</platform></storetype>';
         } else {
             const pyScriptName: string = path.basename(pythonScript.fullPath);
             this._templateString +=
-                `<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath><script>@USIPLUGINDIREX@DataPlugins\\${dataPluginName}\\${pyScriptName}</script>]]></easypluginparam>` +
-                '<querysupported>0</querysupported>' +
-                '<fastloadsupported>0</fastloadsupported>' +
-                `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
+                `<script>@USIPLUGINDIREX@DataPlugins\\${dataPluginName}\\${pyScriptName}</script>]]></easypluginparam>` +
                 '<platform>x64</platform></storetype>' +
                 `<files><file name="${dataPluginName}"><![CDATA[${pythonScript.content}]]>` +
-                `<checksum>${pythonScript.checksum}</checksum></file></files>` +
-                '</usireginfo>';
+                `<checksum>${pythonScript.checksum}</checksum></file></files>`;
         }
+
+        this._templateString += '</usireginfo>';
     }
 
     /**

--- a/src/uri-template.ts
+++ b/src/uri-template.ts
@@ -1,24 +1,55 @@
-class UriTemplate {
+export interface PythonScript {
+    content: string;
+    checksum: number;
+}
+
+export class UriTemplate {
     private readonly _templateString: string = '';
-    public constructor(fileName: string, pythonScriptPath: string, fileExtensions: string) {
-        this._templateString =
-            `<usireginfo><storetype name="${fileName}">` +
-            '<type>python</type>' +
-            `<alias>${fileName}</alias>` +
-            `<description>${fileName}</description>` +
-            '<filepath>uspTdmMarshaller.dll</filepath>' +
-            '<exportsupported>NO</exportsupported>' +
-            '<caching>YES</caching>' +
-            `<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath><script>${pythonScriptPath}</script>]]></easypluginparam>` +
-            '<querysupported>0</querysupported>' +
-            '<fastloadsupported>0</fastloadsupported>' +
-            `<filefilters extension="${fileExtensions}"><description>${fileName} Files (${fileExtensions})</description></filefilters>` +
-            '<platform>x64</platform></storetype></usireginfo>';
+    /**
+     * @param fileName file name of script
+     * @param pythonScript full file path to script or file content and its crc32 checksum
+     * @param fileExtensions supported file extensions of the DataPlugin
+     */
+    public constructor(
+        fileName: string,
+        pythonScript: string | PythonScript,
+        fileExtensions: string
+    ) {
+        if (typeof pythonScript === 'string') {
+            this._templateString =
+                `<usireginfo><storetype name="${fileName}">` +
+                '<type>python</type>' +
+                `<alias>${fileName}</alias>` +
+                `<description>${fileName}</description>` +
+                '<filepath>uspTdmMarshaller.dll</filepath>' +
+                '<exportsupported>NO</exportsupported>' +
+                '<caching>YES</caching>' +
+                `<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath><script>${pythonScript}</script>]]></easypluginparam>` +
+                '<querysupported>0</querysupported>' +
+                '<fastloadsupported>0</fastloadsupported>' +
+                `<filefilters extension="${fileExtensions}"><description>${fileName} Files (${fileExtensions})</description></filefilters>` +
+                '<platform>x64</platform></storetype></usireginfo>';
+        } else {
+            this._templateString =
+                `<usireginfo><storetype name="${fileName}">` +
+                '<type>python</type>' +
+                `<alias>${fileName}</alias>` +
+                `<description>${fileName}</description>` +
+                '<filepath>uspTdmMarshaller.dll</filepath>' +
+                '<exportsupported>NO</exportsupported>' +
+                '<caching>YES</caching>' +
+                `<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath><script>${pythonScript.content}</script>]]></easypluginparam>` +
+                '<querysupported>0</querysupported>' +
+                '<fastloadsupported>0</fastloadsupported>' +
+                `<filefilters extension="${fileExtensions}"><description>${fileName} Files (${fileExtensions})</description></filefilters>` +
+                '<platform>x64</platform></storetype></usireginfo>';
+        }
     }
 
+    /**
+        Returns the uri template
+     */
     public get templateString(): string {
         return this._templateString;
     }
 }
-
-export default UriTemplate;

--- a/src/vscode-utils.ts
+++ b/src/vscode-utils.ts
@@ -16,9 +16,10 @@ export async function exportDataPlugin(
     scriptPath: string,
     fileExtensions: string,
     exportPath: string,
+    embedScript = false,
     promptInfoMessage = true
 ): Promise<void> {
-    await fileutils.writeUriFile(scriptPath, fileExtensions, exportPath);
+    await fileutils.writeUriFile(scriptPath, fileExtensions, exportPath, embedScript);
 
     if (!promptInfoMessage) {
         return;
@@ -29,6 +30,7 @@ export async function exportDataPlugin(
         'Open in Explorer',
         'Register DataPlugin'
     );
+
     if (result === 'Open in Explorer') {
         await open(path.dirname(exportPath));
     }


### PR DESCRIPTION
# Justification

When exporting a DataPlugin, we want to embed the script into the URI file. It must contain the entire script and the according crc32 checksum.

# Implementation

- For crc generation we make use of the following npm module: https://www.npmjs.com/package/crc
- The writeUriFile method has been extended and can either embed the script or reference it

# Testing

Basic unit tests for crc generation and uri file writing added.