### PR TITLE
Fix number of file extension dots

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -180,7 +180,7 @@ async function createDataPluginFromSampleFile(dataPlugin: DataPlugin): Promise<D
         if (fileExtension) {
             fileutils.storeFileExtensionConfig(
                 path.dirname(dataPlugin.scriptPath),
-                `*.${fileExtension}`
+                `*${fileExtension}`
             );
         }
 


### PR DESCRIPTION
# Justification
path.extname already provides the dot for the file extension. Can be removed from the string.