### PR TITLE
Define type for ExportOptions

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -117,7 +117,10 @@ export async function exportPlugin(uri: vscode.Uri): Promise<void> {
         exportPath = path.join(exportPath, `${pluginName}.uri`);
     }
 
-    await vscu.exportDataPlugin(scriptPath, extensions.toString(), `${exportPath}`, true);
+    await vscu.exportDataPlugin(scriptPath, extensions.toString(), `${exportPath}`, {
+        embedScript: true,
+        promptInfoMessage: true
+    });
 
     // Store selected extensions so we don't have to ask again
     fileutils.storeFileExtensionConfig(path.dirname(scriptPath), extensions);
@@ -132,7 +135,10 @@ export async function registerPlugin(uri: vscode.Uri): Promise<void> {
         return;
     }
 
-    await vscu.exportDataPlugin(scriptPath, extensions.toString(), `${exportPath}`);
+    await vscu.exportDataPlugin(scriptPath, extensions.toString(), `${exportPath}`, {
+        embedScript: false,
+        promptInfoMessage: false
+    });
     const process = await open(exportPath);
     process.on('exit', rc => {
         const foundUsiReg = rc === 0;

--- a/src/vscode-utils.ts
+++ b/src/vscode-utils.ts
@@ -12,16 +12,19 @@ export async function disposeDataPlugin(dataPlugin: DataPlugin): Promise<void> {
     void fs.remove(pluginFolder);
 }
 
+interface ExportOptions {
+    embedScript?: boolean;
+    promptInfoMessage?: boolean;
+}
 export async function exportDataPlugin(
     scriptPath: string,
     fileExtensions: string,
     exportPath: string,
-    embedScript = false,
-    promptInfoMessage = true
+    options: ExportOptions
 ): Promise<void> {
-    await fileutils.writeUriFile(scriptPath, fileExtensions, exportPath, embedScript);
+    await fileutils.writeUriFile(scriptPath, fileExtensions, exportPath, options.embedScript);
 
-    if (!promptInfoMessage) {
+    if (!options.promptInfoMessage) {
         return;
     }
 


### PR DESCRIPTION
# Justification
Easier readability with defined type for export options. Behaves like named arguments now.