### PR TITLE
Fix exported URI files are damaged

### DIFF
--- a/src/crc.ts
+++ b/src/crc.ts
@@ -2,8 +2,9 @@ import { crc32 } from 'crc';
 
 class CRC {
     public static crc32(data: string): number {
-        // The NI DataPlugins checksum is generated from a utf16le string
-        const buffer = Buffer.from(data, 'utf16le');
+        // The NI DataPlugins checksum is generated from a utf16le string with LF only
+        const lfData = data.replace(/\r\n/g, '\n');
+        const buffer = Buffer.from(lfData, 'utf16le');
         return crc32(buffer);
     }
 }

--- a/src/test/suite/crc.test.ts
+++ b/src/test/suite/crc.test.ts
@@ -13,4 +13,16 @@ suite('CRC Test Suite', () => {
         const crc = CRC.crc32('class Plugin: コピ ✔❌😊');
         assert.ok(expectedResult === crc);
     });
+
+    test('should create the correct crc for a string with CRLF', () => {
+        const expectedResult = 102738629;
+        const crlfString = CRC.crc32(
+            '# A simple "hello world" example for CSV-like files\r\nimport os\r\nfrom pathlib import Path\r\n\r\n\r\nclass Plugin:'
+        );
+        assert.ok(expectedResult === crlfString);
+        const lfString = CRC.crc32(
+            '# A simple "hello world" example for CSV-like files\nimport os\nfrom pathlib import Path\n\n\nclass Plugin:'
+        );
+        assert.ok(expectedResult === lfString);
+    });
 });

--- a/src/test/suite/uri-template.test.ts
+++ b/src/test/suite/uri-template.test.ts
@@ -18,12 +18,13 @@ suite('URI-Template Test Suite', () => {
             '<filepath>uspTdmMarshaller.dll</filepath>' +
             '<exportsupported>NO</exportsupported>' +
             '<caching>YES</caching>' +
-            '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>' +
             '<querysupported>0</querysupported>' +
             '<fastloadsupported>0</fastloadsupported>' +
+            '<platform>x64</platform>' +
             `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
+            '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>' +
             `<script>${scriptPath}</script>]]></easypluginparam>` +
-            '<platform>x64</platform></storetype></usireginfo>';
+            '</storetype></usireginfo>';
 
         const uriTemplate = new UriTemplate('MyDataPlugin', 'C:/temp/script.py', '*.csv');
         const templateString = uriTemplate.templateString;
@@ -48,14 +49,14 @@ suite('URI-Template Test Suite', () => {
             '<filepath>uspTdmMarshaller.dll</filepath>' +
             '<exportsupported>NO</exportsupported>' +
             '<caching>YES</caching>' +
-            '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>' +
             '<querysupported>0</querysupported>' +
             '<fastloadsupported>0</fastloadsupported>' +
+            '<platform>x64</platform>' +
             `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
+            '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>' +
             `<script>@USIPLUGINDIREX@DataPlugins\\${dataPluginName}\\script.py</script>]]></easypluginparam>` +
-            '<platform>x64</platform></storetype>' +
-            `<files><file name="${dataPluginName}"><![CDATA[${pythonScript.content}]]>` +
-            `<checksum>${pythonScript.checksum}</checksum></file></files></usireginfo>`;
+            `<files><file name="script.py"><![CDATA[${pythonScript.content}]]>` +
+            `<checksum>${pythonScript.checksum}</checksum></file></files></storetype></usireginfo>`;
 
         const uriTemplate = new UriTemplate('MyDataPlugin', pythonScript, '*.csv');
         const templateString = uriTemplate.templateString;

--- a/src/uri-template.ts
+++ b/src/uri-template.ts
@@ -26,25 +26,23 @@ export class UriTemplate {
             '<filepath>uspTdmMarshaller.dll</filepath>' +
             '<exportsupported>NO</exportsupported>' +
             '<caching>YES</caching>' +
-            '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>' +
             '<querysupported>0</querysupported>' +
             '<fastloadsupported>0</fastloadsupported>' +
-            `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>`;
+            '<platform>x64</platform>' +
+            `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
+            '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>';
 
         if (typeof pythonScript === 'string') {
-            this._templateString +=
-                `<script>${pythonScript}</script>]]></easypluginparam>` +
-                '<platform>x64</platform></storetype>';
+            this._templateString += `<script>${pythonScript}</script>]]></easypluginparam>`;
         } else {
             const pyScriptName: string = path.basename(pythonScript.fullPath);
             this._templateString +=
                 `<script>@USIPLUGINDIREX@DataPlugins\\${dataPluginName}\\${pyScriptName}</script>]]></easypluginparam>` +
-                '<platform>x64</platform></storetype>' +
-                `<files><file name="${dataPluginName}"><![CDATA[${pythonScript.content}]]>` +
+                `<files><file name="${pyScriptName}"><![CDATA[${pythonScript.content}]]>` +
                 `<checksum>${pythonScript.checksum}</checksum></file></files>`;
         }
 
-        this._templateString += '</usireginfo>';
+        this._templateString += '</storetype></usireginfo>';
     }
 
     /**


### PR DESCRIPTION
# Justification
- Exported URI files were damaged when reading a file with CRLF line feeds. The checksum has to built from LF.
- In addition the URI xml structure was not compliant and had to be restructured.

# Implementation
Use regex to replace CRLF by LF.

# Testing
Unit tests extended