### PR TITLE
Allow to register DataPlugin with ctrl+alt+f5

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "keybindings": [
         {
             "command": "nipy.registerPlugin",
-            "key": "ctrl+F5",
+            "key": "ctrl+alt+F5",
             "when": "editorTextFocus"
         }
     ],

--- a/package.json
+++ b/package.json
@@ -45,6 +45,13 @@
         "category": "NI DataPlugins"
       }
     ],
+    "keybindings": [
+        {
+            "command": "nipy.registerPlugin",
+            "key": "ctrl+F5",
+            "when": "editorTextFocus"
+        }
+    ],
     "configuration": [
       {
         "title": "Vscode-NI-Python-DataPlugins",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -127,7 +127,11 @@ export async function exportPlugin(uri: vscode.Uri): Promise<void> {
 }
 
 export async function registerPlugin(uri: vscode.Uri): Promise<void> {
-    const scriptPath: string = uri.fsPath;
+    const scriptPath = uri?.fsPath ?? vscu.getOpenPythonScript()?.fsPath;
+    if (!scriptPath) {
+        return;
+    }
+
     const pluginName: string = path.basename(path.dirname(scriptPath));
     const exportPath: string = path.join(os.tmpdir(), `${pluginName}.uri`);
     const extensions = await readOrRequestFileExtensionConfig(uri);

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -1,4 +1,7 @@
+import * as assert from 'assert';
+import * as path from 'path';
 import * as vscode from 'vscode';
+import * as vscu from '../../vscode-utils';
 
 suite('Commands Test Suite', () => {
     void vscode.window.showInformationMessage('Start Commands tests.');
@@ -31,5 +34,24 @@ suite('Commands Test Suite', () => {
         } catch (error) {
             done(new Error(error));
         }
+    }).timeout(60000);
+
+    test('should be able to get the currently open python file', async () => {
+        const pythonFile = vscode.Uri.file(
+            `${__dirname}\\..\\..\\..\\examples\\hello_world\\hello_world.py`
+        );
+
+        const mdFile = vscode.Uri.file(
+            `${__dirname}\\..\\..\\..\\examples\\hello_world\\README.md`
+        );
+
+        await vscode.commands.executeCommand('vscode.open', pythonFile);
+        const openFile = vscu.getOpenPythonScript();
+        assert.ok(!!openFile);
+        assert.strictEqual(path.resolve(pythonFile.fsPath), path.resolve(openFile.fsPath));
+
+        await vscode.commands.executeCommand('vscode.open', mdFile);
+        const r = vscu.getOpenPythonScript();
+        assert.ok(!r);
     }).timeout(60000);
 });

--- a/src/vscode-utils.ts
+++ b/src/vscode-utils.ts
@@ -54,6 +54,16 @@ export function loadExamples(): Example[] {
     return examples;
 }
 
+export function getOpenPythonScript(): vscode.Uri | undefined {
+    const uri = vscode.window.activeTextEditor?.document.uri;
+    const isPython = path.extname(uri?.fsPath ?? '') === '.py';
+    if (uri && isPython) {
+        return uri;
+    }
+
+    return undefined;
+}
+
 export function isDocumentEmpty(): boolean {
     return !vscode.window.activeTextEditor?.document.getText.toString();
 }


### PR DESCRIPTION
# Justification
Registering the currently open python file with usiReg is a very common work flow. It makes sense to assign that action to a key binding. 

# Implementation
Reusing the `nipy.registerPlugin` command but it needs to handle two scenarios now:
- Called from context menu
- Called with keybinding from current open editor

# Testing
Test for `getOpenPythonScript` added