### PR TITLE
Better input validation when asking for file extensions

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -226,13 +226,22 @@ async function readOrRequestFileExtensionConfig(uri: vscode.Uri): Promise<string
     }
 
     if (!extensions) {
-        extensions = await vscu.showInputBox(
-            'Please enter the file extensions your DataPlugin can handle in the right syntax: ',
-            '*.tdm; *.xls ...'
-        );
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            // eslint-disable-next-line no-await-in-loop
+            extensions = await vscu.showInputBox(
+                'Please enter the file extensions your DataPlugin can handle in the right syntax: ',
+                '*.tdm; *.xls ...'
+            );
 
-        if (!extensions) {
-            return '';
+            if (!extensions) {
+                return '';
+            }
+
+            const isValidInput = vscu.isValidFileExtensionInput(extensions);
+            if (isValidInput) {
+                break;
+            }
         }
     }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -230,7 +230,7 @@ async function readOrRequestFileExtensionConfig(uri: vscode.Uri): Promise<string
         while (true) {
             // eslint-disable-next-line no-await-in-loop
             extensions = await vscu.showInputBox(
-                'Please enter the file extensions your DataPlugin can handle in the right syntax: ',
+                'Enter the file extension(s) your DataPlugin handles using the following syntax: ',
                 '*.tdm; *.xls ...'
             );
 

--- a/src/test/suite/vscode-utils.test.ts
+++ b/src/test/suite/vscode-utils.test.ts
@@ -1,0 +1,21 @@
+import * as assert from 'assert';
+import * as vscu from '../../vscode-utils';
+
+suite('VSCode-Utils Test Suite', () => {
+    test('should correctly return validity for a file extension input string', () => {
+        assert.ok(vscu.isValidFileExtensionInput('*.csv'));
+        assert.ok(vscu.isValidFileExtensionInput('*.csv;'));
+        assert.ok(vscu.isValidFileExtensionInput('*.csv;*.txt'));
+        assert.ok(vscu.isValidFileExtensionInput('*.csv;*.txt;'));
+        assert.ok(vscu.isValidFileExtensionInput('*.csv; *.txt;'));
+
+        assert.ok(vscu.isValidFileExtensionInput('csv') === false);
+        assert.ok(vscu.isValidFileExtensionInput('csv;') === false);
+        assert.ok(vscu.isValidFileExtensionInput('.csv') === false);
+        assert.ok(vscu.isValidFileExtensionInput('.csv;') === false);
+        assert.ok(vscu.isValidFileExtensionInput('*.csv;;') === false);
+        assert.ok(vscu.isValidFileExtensionInput('*.csv*.txt') === false);
+        assert.ok(vscu.isValidFileExtensionInput('*.csv;.txt;') === false);
+        assert.ok(vscu.isValidFileExtensionInput('*.csv;txt;') === false);
+    });
+});

--- a/src/vscode-utils.ts
+++ b/src/vscode-utils.ts
@@ -65,13 +65,13 @@ export function isValidFileExtensionInput(input: string): boolean {
     const matchSingleExtension = input?.match(regExSingleExtension);
     const matchMultipleExtensions = input?.match(regExMultipleExtensions);
 
-    let matchArray = matchSingleExtension;
+    let matches = matchSingleExtension;
     if (matchMultipleExtensions) {
-        matchArray = matchMultipleExtensions;
+        matches = matchMultipleExtensions;
     }
 
-    const isFullMatch = matchArray?.join().length === input?.length;
-    const isValidInput = !!matchArray && isFullMatch;
+    const isFullMatch = matches?.join().length === input?.length;
+    const isValidInput = !!matches && isFullMatch;
     return isValidInput;
 }
 

--- a/src/vscode-utils.ts
+++ b/src/vscode-utils.ts
@@ -58,6 +58,23 @@ export function isDocumentEmpty(): boolean {
     return !vscode.window.activeTextEditor?.document.getText.toString();
 }
 
+export function isValidFileExtensionInput(input: string): boolean {
+    const regExSingleExtension = new RegExp(/^\*\.[a-zA-Z]*(;)*/gm); // *.csv || *.csv;
+    const regExMultipleExtensions = new RegExp(/^\*\.[a-zA-Z]*(;)(\s)?(\*\.[a-zA-Z]*(;)*)*/gm); // *.csv;*.txt || *.csv;*.txt; || *.csv; *.txt;
+
+    const matchSingleExtension = input?.match(regExSingleExtension);
+    const matchMultipleExtensions = input?.match(regExMultipleExtensions);
+
+    let matchArray = matchSingleExtension;
+    if (matchMultipleExtensions) {
+        matchArray = matchMultipleExtensions;
+    }
+
+    const isFullMatch = matchArray?.join().length === input?.length;
+    const isValidInput = !!matchArray && isFullMatch;
+    return isValidInput;
+}
+
 export async function openDocumentAndShow(docPath: string): Promise<vscode.TextEditor> {
     const textDocument = await vscode.workspace.openTextDocument(docPath);
     return vscode.window.showTextDocument(textDocument);


### PR DESCRIPTION
# Justification
We need better input validation when prompting for file extensions:

![image](https://user-images.githubusercontent.com/79531/121376862-2b839400-c942-11eb-81e4-b8986f1815fd.png)

# Implementation
Basically two RegEx expressions

# Testing
Test for validity regex algorithm added