### PR TITLE
Using path.join when possible

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -22,7 +22,8 @@ export async function createDataPlugin(): Promise<DataPlugin | null> {
         return null;
     }
 
-    if (fs.existsSync(`${config.dataPluginFolder}\\${dataPluginName}`)) {
+    const pluginFolder = path.join(config.dataPluginFolder, dataPluginName);
+    if (fs.existsSync(pluginFolder)) {
         await vscode.window.showInformationMessage(
             `${config.extPrefix} There is already a DataPlugin named "${dataPluginName}"!`
         );
@@ -104,7 +105,7 @@ export async function exportPlugin(uri: vscode.Uri): Promise<void> {
     if (!exportPath) {
         const options: vscode.SaveDialogOptions = {
             defaultUri: vscode.Uri.file(
-                `${config.dataPluginFolder}\\${pluginName}\\${pluginName}.uri`
+                path.join(config.dataPluginFolder, pluginName, `${pluginName}.uri`)
             ),
             // eslint-disable-next-line @typescript-eslint/naming-convention
             filters: { Uri: ['uri'] }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,6 @@ import * as homedir from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 export const userDocuments = path.join(homedir.homedir(), 'Documents');
 export const dataPluginFolder = path.join(userDocuments, 'NI-Python-DataPlugins');
 export const extPrefix = 'NI DataPlugins: ';

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,10 @@
 import * as homedir from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 
 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-export const userDocuments = `${homedir.homedir}\\Documents`;
-export const dataPluginFolder = `${userDocuments}\\NI_DataPlugin`;
+export const userDocuments = path.join(homedir.homedir(), 'Documents');
+export const dataPluginFolder = path.join(userDocuments, 'NI-Python-DataPlugins');
 export const extPrefix = 'NI DataPlugins: ';
 // eslint-disable-next-line operator-linebreak
 export const niConfig: vscode.WorkspaceConfiguration =

--- a/src/dataplugin.ts
+++ b/src/dataplugin.ts
@@ -54,8 +54,8 @@ class DataPlugin {
         this._name = name;
         this._baseTemplate = baseTemplate;
         this._language = language;
-        this._folderPath = `${dataPluginFolder}\\${name}`;
-        this._scriptPath = `${dataPluginFolder}\\${name}\\${baseTemplate}.py`;
+        this._folderPath = path.join(dataPluginFolder, name);
+        this._scriptPath = path.join(dataPluginFolder, name, `${baseTemplate}.py`);
 
         if (fs.existsSync(this.scriptPath)) {
             throw new FileExistsError(`${config.extPrefix}DataPlugin already exists`);

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -38,12 +38,10 @@ suite('Commands Test Suite', () => {
 
     test('should be able to get the currently open python file', async () => {
         const pythonFile = vscode.Uri.file(
-            `${__dirname}\\..\\..\\..\\examples\\hello_world\\hello_world.py`
+            `${__dirname}/../../../examples/hello_world/hello_world.py`
         );
 
-        const mdFile = vscode.Uri.file(
-            `${__dirname}\\..\\..\\..\\examples\\hello_world\\README.md`
-        );
+        const mdFile = vscode.Uri.file(`${__dirname}/../../../examples/hello_world/README.md`);
 
         await vscode.commands.executeCommand('vscode.open', pythonFile);
         const openFile = vscu.getOpenPythonScript();

--- a/src/test/suite/dataplugin.test.ts
+++ b/src/test/suite/dataplugin.test.ts
@@ -37,7 +37,7 @@ suite('DataPlugin Test Suite', () => {
         assert.ok(dataPlugin.baseTemplate === baseTemplate);
         assert.ok(
             dataPlugin.scriptPath ===
-                `${config.dataPluginFolder}\\${dataPlugin.name}\\${baseTemplate}.py`
+                path.join(config.dataPluginFolder, dataPlugin.name, `${baseTemplate}.py`)
         );
     }).timeout(10000);
 
@@ -60,7 +60,7 @@ suite('DataPlugin Test Suite', () => {
             assert.ok(dataPlugin.baseTemplate === examplesName);
             assert.ok(
                 dataPlugin.scriptPath ===
-                    `${config.dataPluginFolder}\\${dataPlugin.name}\\${examplesName}.py`
+                    path.join(config.dataPluginFolder, dataPlugin.name, `${examplesName}.py`)
             );
         }
     }).timeout(10000);

--- a/src/vscode-utils.ts
+++ b/src/vscode-utils.ts
@@ -43,7 +43,7 @@ export async function exportDataPlugin(
 }
 
 export function loadExamples(): Example[] {
-    const examplesFolder = path.resolve(`${path.dirname(__dirname)}\\examples`);
+    const examplesFolder = path.resolve(path.join(path.dirname(__dirname), 'examples'));
     const examplesNames: string[] = fs
         .readdirSync(examplesFolder)
         .filter(folder => fs.statSync(path.join(examplesFolder, folder)).isDirectory());


### PR DESCRIPTION
# Justification

- Using `path.join` when possible to concatenate paths. Manually concatenating causes problem in Linux.
- Changed name of default plugin folder in \\Documents