### PR TITLE
Add usi compatibility version to uri

### DIFF
--- a/src/test/suite/uri-template.test.ts
+++ b/src/test/suite/uri-template.test.ts
@@ -11,7 +11,7 @@ suite('URI-Template Test Suite', () => {
         const fileExtensions = '*.csv';
 
         const comparison =
-            `<usireginfo><storetype name="${dataPluginName}">` +
+            `<usireginfo version="${UriTemplate.usiCompatibilityVersion}"><storetype name="${dataPluginName}">` +
             '<type>python</type>' +
             `<alias>${dataPluginName}</alias>` +
             `<description>${dataPluginName}</description>` +
@@ -42,7 +42,7 @@ suite('URI-Template Test Suite', () => {
         };
 
         const comparison =
-            `<usireginfo><storetype name="${dataPluginName}">` +
+            `<usireginfo version="${UriTemplate.usiCompatibilityVersion}"><storetype name="${dataPluginName}">` +
             '<type>python</type>' +
             `<alias>${dataPluginName}</alias>` +
             `<description>${dataPluginName}</description>` +
@@ -62,4 +62,10 @@ suite('URI-Template Test Suite', () => {
         const templateString = uriTemplate.templateString;
         assert.strictEqual(comparison, templateString);
     }).timeout(10000);
+
+    test('should return a USI compatibility version with semantic formatting', () => {
+        const usiCompatibilityVersion = UriTemplate.usiCompatibilityVersion;
+        const split = usiCompatibilityVersion.split('.');
+        assert.strictEqual(split.length, 3);
+    });
 });

--- a/src/uri-template.ts
+++ b/src/uri-template.ts
@@ -7,7 +7,9 @@ export interface PythonScript {
 }
 
 export class UriTemplate {
+    public static readonly usiCompatibilityVersion: string = '20.0.0';
     private readonly _templateString: string = '';
+
     /**
      * @param dataPluginName name of DataPlugin and uri
      * @param pythonScript full file path to script or object of file content, crc32 and name
@@ -19,7 +21,7 @@ export class UriTemplate {
         fileExtensions: string
     ) {
         this._templateString =
-            `<usireginfo><storetype name="${dataPluginName}">` +
+            `<usireginfo version="${UriTemplate.usiCompatibilityVersion}"><storetype name="${dataPluginName}">` +
             '<type>python</type>' +
             `<alias>${dataPluginName}</alias>` +
             `<description>${dataPluginName}</description>` +


### PR DESCRIPTION
# Justification

We need to prevent that Python DataPlugin URI files can be registered for older USI versions

# Testing

- Adjusted uri template test
- Minimal test added that ensures the version string has the right semantic