### PR TITLE
Naming of main python file

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -210,7 +210,6 @@ async function createDataPluginFromSampleFile(dataPluginName: string): Promise<D
         // manipulate script
         try {
             dataPlugin.replaceStringInScript('Example.csv', sampleFileName);
-            dataPlugin.renameDataPluginScript(dataPlugin.name);
         } catch (e) {
             if (e instanceof Error) {
                 void vscode.window.showErrorMessage(e.message);

--- a/src/dataplugin.ts
+++ b/src/dataplugin.ts
@@ -73,10 +73,6 @@ class DataPlugin {
     }
 
     /**
-     * @param newName New name of script file. Provide name without file extension
-     */
-
-    /**
      * @param substr A String that is to be replaced by newSubstr
      * @param newSubStr Replacement string
      */

--- a/src/dataplugin.ts
+++ b/src/dataplugin.ts
@@ -75,12 +75,6 @@ class DataPlugin {
     /**
      * @param newName New name of script file. Provide name without file extension
      */
-    public renameDataPluginScript(newName: string): void {
-        const scriptPath = this.scriptPath;
-        const newScriptPath = path.join(path.dirname(scriptPath), `${newName}.py`);
-        fs.renameSync(scriptPath, newScriptPath);
-        this.scriptPath = newScriptPath;
-    }
 
     /**
      * @param substr A String that is to be replaced by newSubstr
@@ -115,11 +109,19 @@ class DataPlugin {
                 path.join(this.folderPath, '.vscode', launchFile)
             );
 
+            this.renameDataPluginScript(this.name);
             await Promise.resolve();
             return;
         } catch (e) {
             throw new Error(`${config.extPrefix}Failed to create DataPlugin!`);
         }
+    }
+
+    private renameDataPluginScript(newName: string): void {
+        const scriptPath = this.scriptPath;
+        const newScriptPath = path.join(path.dirname(scriptPath), `${newName}.py`);
+        fs.renameSync(scriptPath, newScriptPath);
+        this.scriptPath = newScriptPath;
     }
 }
 

--- a/src/test/e2e/create-plugin.test.ts
+++ b/src/test/e2e/create-plugin.test.ts
@@ -36,6 +36,7 @@ describe('Basic UI Tests', () => {
         await new Promise(res => setTimeout(res, 500));
         await chooseTemplateDropDown.setText('hello_world');
         await chooseTemplateDropDown.confirm();
+        await new Promise(res => setTimeout(res, 5000));
 
         // Project with correct name created in SideBar?
         const sideBarView = await driver.wait(() => new SideBarView(), 5000);

--- a/src/test/e2e/settings.json
+++ b/src/test/e2e/settings.json
@@ -1,4 +1,5 @@
 {
+   "security.workspace.trust.enabled": false,
    "typescript.updateImportsOnFileMove.enabled": "always",
    "workbench.editor.enablePreview": true,
    "update.mode": "none"

--- a/src/test/suite/dataplugin.test.ts
+++ b/src/test/suite/dataplugin.test.ts
@@ -65,20 +65,6 @@ suite('DataPlugin Test Suite', () => {
         }
     }).timeout(10000);
 
-    test('should correctly rename the main DataPlugin script', async () => {
-        const randomName: string = Guid.create().toString();
-        const dataPlugin: DataPlugin = await DataPlugin.createDataPlugin(
-            randomName,
-            'hello_world',
-            Languages.Python
-        );
-        const originalScriptPath = dataPlugin.scriptPath;
-        dataPlugin.renameDataPluginScript('new_name');
-        assert.notStrictEqual(originalScriptPath, dataPlugin.scriptPath);
-        assert.strictEqual(path.dirname(originalScriptPath), path.dirname(dataPlugin.scriptPath));
-        assert.strictEqual(path.basename(dataPlugin.scriptPath), 'new_name.py');
-    }).timeout(10000);
-
     test('should correctly replace a string in the main DataPlugin script', async () => {
         const randomName: string = Guid.create().toString();
         const dataPlugin: DataPlugin = await DataPlugin.createDataPlugin(

--- a/src/test/suite/dataplugin.test.ts
+++ b/src/test/suite/dataplugin.test.ts
@@ -37,7 +37,7 @@ suite('DataPlugin Test Suite', () => {
         assert.ok(dataPlugin.baseTemplate === baseTemplate);
         assert.ok(
             dataPlugin.scriptPath ===
-                path.join(config.dataPluginFolder, dataPlugin.name, `${baseTemplate}.py`)
+                path.join(config.dataPluginFolder, dataPlugin.name, `${dataPlugin.name}.py`)
         );
     }).timeout(10000);
 
@@ -60,7 +60,7 @@ suite('DataPlugin Test Suite', () => {
             assert.ok(dataPlugin.baseTemplate === examplesName);
             assert.ok(
                 dataPlugin.scriptPath ===
-                    path.join(config.dataPluginFolder, dataPlugin.name, `${examplesName}.py`)
+                    path.join(config.dataPluginFolder, dataPlugin.name, `${dataPlugin.name}.py`)
             );
         }
     }).timeout(10000);


### PR DESCRIPTION
# Justification

- The main python file should always have the name of the DataPlugin + '.py'
- Work on robusting e2e tests, especially the new Workspace Trusting has to be disabled upfront

# Testing

- Tests adjusted
- One test was removed because `renameDataPluginScript` became a private method