### PR TITLE
use join to create paths

### DIFF
--- a/examples/csv_read_with_callback_loading/csv_read_with_callback_loading.py
+++ b/examples/csv_read_with_callback_loading/csv_read_with_callback_loading.py
@@ -18,7 +18,7 @@ class Plugin:
             tab_delimiter = "\t"
             # skip the first 4 lines
             # for i in range(4):
-               #  csvfile.readline()
+            #  csvfile.readline()
             reader = csv.DictReader(csvfile, delimiter=tab_delimiter)
             self.data = list(reader)
             self.channelNames = reader.fieldnames
@@ -98,7 +98,7 @@ class Plugin:
             else:
                 value = None
             values.append(value)
-        return values[numberToSkip : numberToTake + numberToSkip]  # noqa: E203
+        return values[numberToSkip: numberToTake + numberToSkip]  # noqa: E203
 
 
 if __name__ == "__main__":
@@ -107,7 +107,9 @@ if __name__ == "__main__":
     )
     p = Plugin()
     dir_path = os.path.dirname(os.path.realpath(__file__))
-    parameter = {"file": dir_path + "\\Example.csv"}
+    parameter = {
+        "file": os.path.join(dir_path, "Example.csv")
+    }
     print("\n %s" % p.read_store(parameter))
     print("\nChannel length: %s" % p.read_channel_length(0, 0))
     print("\nChannel values: %s" % p.read_channel_values(0, 0, 0, 1024))

--- a/examples/csv_read_with_direct_loading/csv_read_with_direct_loading.py
+++ b/examples/csv_read_with_direct_loading/csv_read_with_direct_loading.py
@@ -19,7 +19,7 @@ class Plugin:
             tab_delimiter = "\t"
             # skip the first 4 lines
             # for i in range(4):
-               #  csvfile.readline()
+            #  csvfile.readline()
             reader = csv.DictReader(csvfile, delimiter=tab_delimiter)
             self.data = list(reader)
             self.channelNames = reader.fieldnames
@@ -106,5 +106,7 @@ if __name__ == "__main__":
     )
     p = Plugin()
     dir_path = os.path.dirname(os.path.realpath(__file__))
-    parameter = {"file": dir_path + "\\Example.csv"}
+    parameter = {
+        "file": os.path.join(dir_path, "Example.csv")
+    }
     print("\n %s" % p.read_store(parameter))

--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -71,5 +71,7 @@ if __name__ == "__main__":
     )
     p = Plugin()
     dir_path = os.path.dirname(os.path.realpath(__file__))
-    parameter = {"file": dir_path + "\\Example.csv"}
+    parameter = {
+        "file": os.path.join(dir_path, "Example.csv")
+    }
     print("\n %s" % p.read_store(parameter))

--- a/examples/npy_read_numpy_array_dump/npy_read_numpy_array_dump.py
+++ b/examples/npy_read_numpy_array_dump/npy_read_numpy_array_dump.py
@@ -111,6 +111,8 @@ if __name__ == "__main__":
     )
     p = Plugin()
     dir_path = os.path.dirname(os.path.realpath(__file__))
-    parameter = {"file": dir_path + "\\Example.npy"}
+    parameter = {
+        "file": os.path.join(dir_path, "Example.npy")
+    }
 
     print("\n %s" % p.read_store(parameter))


### PR DESCRIPTION
# Justification
Creating path with string concatenation and \ does not work on all file systems

# Implementation
use os.path.join method instead

# Testing
manual