### PR TITLE
Adjust import in test script according to DataPlugin name

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -209,7 +209,7 @@ async function createDataPluginFromSampleFile(dataPluginName: string): Promise<D
 
         // manipulate script
         try {
-            dataPlugin.replaceStringInScript('Example.csv', sampleFileName);
+            fileutils.replaceStringInScript(dataPlugin.scriptPath, 'Example.csv', sampleFileName);
         } catch (e) {
             if (e instanceof Error) {
                 void vscode.window.showErrorMessage(e.message);

--- a/src/dataplugin.ts
+++ b/src/dataplugin.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as config from './config';
+import * as fileutils from './file-utils';
 import { FileExistsError } from './dataplugin-error';
 import Languages from './plugin-languages.enum';
 
@@ -72,17 +73,6 @@ class DataPlugin {
         return dataPlugin;
     }
 
-    /**
-     * @param substr A String that is to be replaced by newSubstr
-     * @param newSubStr Replacement string
-     */
-    public replaceStringInScript(substr: string, newSubStr: string): void {
-        const scriptPath = this.scriptPath;
-        let content = fs.readFileSync(scriptPath, { encoding: 'utf8' });
-        content = content.replace(substr, newSubStr);
-        fs.writeFileSync(scriptPath, content);
-    }
-
     private async prepareWorkspace(): Promise<void> {
         try {
             const extensionsFile = '.file-extensions';
@@ -106,6 +96,12 @@ class DataPlugin {
             );
 
             this.renameDataPluginScript(this.name);
+
+            const testScript = path.join(this.folderPath, 'test_plugin.py');
+            if (fs.existsSync(testScript)) {
+                fileutils.replaceStringInScript(testScript, this.baseTemplate, this.name);
+            }
+
             await Promise.resolve();
             return;
         } catch (e) {

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -36,6 +36,17 @@ export async function readFileExtensionConfig(workspaceDir: string): Promise<str
     return Promise.reject(new Error('file not found'));
 }
 
+/**
+ * @param scriptPath A full path to the script
+ * @param substr A String that is to be replaced by newSubstr
+ * @param newSubStr Replacement string
+ */
+export function replaceStringInScript(scriptPath: string, substr: string, newSubStr: string): void {
+    let content = fs.readFileSync(scriptPath, { encoding: 'utf8' });
+    content = content.replace(substr, newSubStr);
+    fs.writeFileSync(scriptPath, content);
+}
+
 export function storeFileExtensionConfig(workspaceDir: string, fileExtensions: string): void {
     const filePath: string = path.join(workspaceDir, '.file-extensions');
     if (fs.existsSync(filePath)) {

--- a/src/test/suite/dataplugin.test.ts
+++ b/src/test/suite/dataplugin.test.ts
@@ -1,7 +1,6 @@
 import { after } from 'mocha';
 import { Guid } from 'guid-typescript';
 import * as assert from 'assert';
-import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as config from '../../config';
@@ -63,20 +62,6 @@ suite('DataPlugin Test Suite', () => {
                     path.join(config.dataPluginFolder, dataPlugin.name, `${dataPlugin.name}.py`)
             );
         }
-    }).timeout(10000);
-
-    test('should correctly replace a string in the main DataPlugin script', async () => {
-        const randomName: string = Guid.create().toString();
-        const dataPlugin: DataPlugin = await DataPlugin.createDataPlugin(
-            randomName,
-            'hello_world',
-            Languages.Python
-        );
-        dataPlugin.replaceStringInScript('Example.csv', 'new_name');
-        const scriptPath = dataPlugin.scriptPath;
-        const content = fs.readFileSync(scriptPath, { encoding: 'utf8' });
-        assert.ok(content.includes('new_name'));
-        assert.ok(content.includes('Example.csv') === false);
     }).timeout(10000);
 
     test('should throw FileExistsError', async () => {

--- a/src/test/suite/file-utils.test.ts
+++ b/src/test/suite/file-utils.test.ts
@@ -63,4 +63,18 @@ suite('File-Utils Test Suite', () => {
         assert.ok(fileContent.includes('CDATA[class Plugin:]'));
         assert.ok(fileContent.includes('1698750118'));
     }).timeout(10000);
+
+    test('should correctly replace a string in the main DataPlugin script', async () => {
+        const testScript: string = path.join(__dirname, 'test.py');
+
+        if (fs.existsSync(testScript)) {
+            fs.unlinkSync(testScript);
+        }
+
+        await fs.writeFile(testScript, 'class Plugin:');
+        fileutils.replaceStringInScript(testScript, 'class', 'ssalc');
+
+        const fileContent = fs.readFileSync(testScript, { encoding: 'utf8' });
+        assert.ok(fileContent.includes('ssalc Plugin:'));
+    }).timeout(10000);
 });


### PR DESCRIPTION
# Justification

When creating a new DataPlugin workspace, we create a default test_script.py. Depending on the DataPlugin name, we have to adjust the import statement in that test script.

# Implementation

- moved `replaceStringInScript` to file utils
- use that method in `prepareWorkspace` to adjust the import statement

# Testing

- Test moved from `dataplugin.test.ts` to `file-utils.test.ts`