### PR TITLE
Fix comment when starting with sample file

### DIFF
--- a/examples/hello_world/hello_world.py
+++ b/examples/hello_world/hello_world.py
@@ -1,4 +1,4 @@
-# A simple "hello world" example for CSV-like files
+# A simple "hello world" example showing the tdm output structure
 import os
 from pathlib import Path
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -210,6 +210,14 @@ async function createDataPluginFromSampleFile(dataPluginName: string): Promise<D
         // manipulate script
         try {
             fileutils.replaceStringInScript(dataPlugin.scriptPath, 'Example.csv', sampleFileName);
+            // remove first comment line
+            const oldCommentaryLine = await fileutils.readFirstLineOfFile(dataPlugin.scriptPath);
+            const newCommentaryLine = "# This is the DataPlugin's main script";
+            fileutils.replaceStringInScript(
+                dataPlugin.scriptPath,
+                oldCommentaryLine,
+                newCommentaryLine
+            );
         } catch (e) {
             if (e instanceof Error) {
                 void vscode.window.showErrorMessage(e.message);


### PR DESCRIPTION
# Justification

When starting with a sample file, we use the `hello_world` example as the base template. However, the commentary line is misleading because the customer is not going to create a `hello_world` DataPlugin. We should replace the first line when preparing the workspace.