### PR TITLE
Allow export and register from commandpalette

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,11 +70,11 @@
       "commandPalette": [
         {
           "command": "nipy.exportPlugin",
-          "when": "false"
+          "when": "editorLangId == python"
         },
         {
           "command": "nipy.registerPlugin",
-          "when": "false"
+          "when": "editorLangId == python"
         }
       ],
       "explorer/context": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -89,11 +89,11 @@ export async function createDataPlugin(): Promise<DataPlugin | null> {
 }
 
 export async function exportPlugin(uri: vscode.Uri): Promise<void> {
-    if (!uri) {
+    const scriptPath = uri?.fsPath ?? vscu.getOpenPythonScript()?.fsPath;
+    if (!scriptPath) {
         return;
     }
 
-    const scriptPath = uri.fsPath;
     const workspaceDir = path.dirname(scriptPath);
     const pluginName = path.basename(path.dirname(scriptPath));
     const extensions = await readOrRequestFileExtensionConfig(workspaceDir);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,8 +10,7 @@ export function activate(context: vscode.ExtensionContext): void {
     const createDataPluginCommand = vscode.commands.registerCommand(
         'nipy.createDataPlugin',
         async () => {
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            commands.createDataPlugin();
+            void commands.createDataPlugin();
         }
     );
     const exportPluginCommand = vscode.commands.registerCommand(


### PR DESCRIPTION
# Justification

It turned out to be a valid workflow to export and register a DataPlugin from the command palette directly. Users don't want to use the context menu in the Explorer-Sidebar for that everytime.

New Command Palette:

![image](https://user-images.githubusercontent.com/79531/123243317-306c4a00-d4e3-11eb-9d81-df77410e8345.png)

# Implementation

Changed package.json to show full command palette when current editor language is `python`

# Testing