### PR TITLE
Include lastexporttime in URI file

### DIFF
--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -67,6 +67,7 @@ export async function writeUriFile(
     embedScript = false
 ): Promise<void> {
     const pluginName = path.basename(path.dirname(scriptPath));
+    const lastExportTime = getEpochTime();
 
     let uriTemplate: UriTemplate;
     if (embedScript) {
@@ -76,10 +77,17 @@ export async function writeUriFile(
             checksum: CRC.crc32(fileContent),
             fullPath: scriptPath
         };
-        uriTemplate = new UriTemplate(pluginName, pyScript, fileExtensions);
+        uriTemplate = new UriTemplate(pluginName, pyScript, fileExtensions, lastExportTime);
     } else {
-        uriTemplate = new UriTemplate(pluginName, scriptPath, fileExtensions);
+        uriTemplate = new UriTemplate(pluginName, scriptPath, fileExtensions, lastExportTime);
     }
 
     await fs.writeFile(exportPath, uriTemplate.templateString, { flag: 'w' });
+}
+
+function getEpochTime(): number {
+    const diffSeconds = 2082844800; // 1/1/1904 to 1/1/1970
+    const unixEpochTime = Math.floor(new Date().getTime() / 1000);
+    const macEpochTime = unixEpochTime + diffSeconds;
+    return macEpochTime;
 }

--- a/src/test/suite/file-utils.test.ts
+++ b/src/test/suite/file-utils.test.ts
@@ -77,4 +77,22 @@ suite('File-Utils Test Suite', () => {
         const fileContent = fs.readFileSync(testScript, { encoding: 'utf8' });
         assert.ok(fileContent.includes('ssalc Plugin:'));
     }).timeout(10000);
+
+    test('should correctly determine the USI lastexporttime', async () => {
+        const testScript: string = path.join(__dirname, 'test.py');
+        const outputUri = path.join(__dirname, 'output.uri');
+
+        if (fs.existsSync(testScript)) {
+            fs.unlinkSync(testScript);
+        }
+
+        const unixEpochTime = Math.floor(new Date().getTime() / 1000);
+        const macEpochTime = unixEpochTime + 2082844800;
+
+        await fs.writeFile(testScript, 'class Plugin:');
+        await fileutils.writeUriFile(testScript, '*.csv', outputUri, true);
+
+        const fileContent = fs.readFileSync(outputUri, { encoding: 'utf8' });
+        assert.ok(fileContent.includes(macEpochTime.toString()));
+    }).timeout(10000);
 });

--- a/src/test/suite/uri-template.test.ts
+++ b/src/test/suite/uri-template.test.ts
@@ -23,10 +23,10 @@ suite('URI-Template Test Suite', () => {
             '<platform>x64</platform>' +
             `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
             '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>' +
-            `<script>${scriptPath}</script>]]></easypluginparam>` +
+            `<script>${scriptPath}</script><lastexporttime>123</lastexporttime>]]></easypluginparam>` +
             '</storetype></usireginfo>';
 
-        const uriTemplate = new UriTemplate('MyDataPlugin', 'C:/temp/script.py', '*.csv');
+        const uriTemplate = new UriTemplate('MyDataPlugin', 'C:/temp/script.py', '*.csv', 123);
         const templateString = uriTemplate.templateString;
         assert.strictEqual(comparison, templateString);
     }).timeout(10000);
@@ -54,11 +54,11 @@ suite('URI-Template Test Suite', () => {
             '<platform>x64</platform>' +
             `<filefilters extension="${fileExtensions}"><description>${dataPluginName} Files (${fileExtensions})</description></filefilters>` +
             '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>' +
-            `<script>@USIPLUGINDIREX@DataPlugins\\${dataPluginName}\\script.py</script>]]></easypluginparam>` +
+            `<script>@USIPLUGINDIREX@DataPlugins\\${dataPluginName}\\script.py</script><lastexporttime>123</lastexporttime>]]></easypluginparam>` +
             `<files><file name="script.py"><![CDATA[${pythonScript.content}]]>` +
             `<checksum>${pythonScript.checksum}</checksum></file></files></storetype></usireginfo>`;
 
-        const uriTemplate = new UriTemplate('MyDataPlugin', pythonScript, '*.csv');
+        const uriTemplate = new UriTemplate('MyDataPlugin', pythonScript, '*.csv', 123);
         const templateString = uriTemplate.templateString;
         assert.strictEqual(comparison, templateString);
     }).timeout(10000);

--- a/src/uri-template.ts
+++ b/src/uri-template.ts
@@ -18,7 +18,8 @@ export class UriTemplate {
     public constructor(
         dataPluginName: string,
         pythonScript: string | PythonScript,
-        fileExtensions: string
+        fileExtensions: string,
+        lastExportTime: number
     ) {
         this._templateString =
             `<usireginfo version="${UriTemplate.usiCompatibilityVersion}"><storetype name="${dataPluginName}">` +
@@ -35,11 +36,12 @@ export class UriTemplate {
             '<easypluginparam><![CDATA[<dllpath>@USIBINDIR@\\PythonMarshaller\\uspPythonMarshaller.dll</dllpath>';
 
         if (typeof pythonScript === 'string') {
-            this._templateString += `<script>${pythonScript}</script>]]></easypluginparam>`;
+            this._templateString += `<script>${pythonScript}</script><lastexporttime>${lastExportTime}</lastexporttime>]]></easypluginparam>`;
         } else {
             const pyScriptName: string = path.basename(pythonScript.fullPath);
             this._templateString +=
-                `<script>@USIPLUGINDIREX@DataPlugins\\${dataPluginName}\\${pyScriptName}</script>]]></easypluginparam>` +
+                `<script>@USIPLUGINDIREX@DataPlugins\\${dataPluginName}\\${pyScriptName}</script>` +
+                `<lastexporttime>${lastExportTime}</lastexporttime>]]></easypluginparam>` +
                 `<files><file name="${pyScriptName}"><![CDATA[${pythonScript.content}]]>` +
                 `<checksum>${pythonScript.checksum}</checksum></file></files>`;
         }


### PR DESCRIPTION
# Justification

We want to include `<lastexporttime>3707447144</lastexporttime>` in the exported URI files. 

# Implementation

The timestamp is not exactly UNIX epoch time (seconds since 1970) but MAC epoch time (seconds since 1904). The difference is 2082844800 seconds. See https://www.epochconverter.com/mac 

# Testing

Test adjusted and a test for checking the timestamp added.